### PR TITLE
Add OpenCV as an optional using cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option(BUILD_SHARED_LIBS "If set, builds as a shared library." ON)
 option(MLIO_INCLUDE_LIB "If set, generates build target for the library." ON)
 option(MLIO_INCLUDE_CONTRIB "If set, generates build target for the contrib library.")
 option(MLIO_INCLUDE_PYTHON_EXTENSION "If set, generates build target for the Python C extension.")
+option(MLIO_BUILD_IMAGE_READER "If set, builds the image reader." OFF)
 
 cmake_dependent_option(
     MLIO_INCLUDE_ARROW_INTEGRATION "If set, generates build target for the Apache Arrow integration." OFF
@@ -300,6 +301,10 @@ if(MLIO_INCLUDE_LIB)
 
     if(MLIO_INCLUDE_TESTS)
         find_package(GTest REQUIRED)
+    endif()
+
+    if(MLIO_BUILD_IMAGE_READER)
+        find_package(OpenCV 4.0 REQUIRED core imgproc imgcodecs)
     endif()
 else()
     find_package(mlio ${PROJECT_VERSION} REQUIRED CONFIG)

--- a/src/mlio/CMakeLists.txt
+++ b/src/mlio/CMakeLists.txt
@@ -116,6 +116,13 @@ target_link_libraries(mlio
         absl::strings dlpack::dlpack fmt::fmt protobuf::libprotobuf TBB::tbb
 )
 
+if(MLIO_BUILD_IMAGE_READER)
+    target_link_libraries(mlio
+        PRIVATE
+            opencv_core opencv_imgcodecs opencv_imgproc
+    )
+endif()
+
 target_link_libraries(mlio
     PRIVATE
         Iconv::Iconv Threads::Threads ZLIB::ZLIB

--- a/tests/mlio-test/CMakeLists.txt
+++ b/tests/mlio-test/CMakeLists.txt
@@ -24,6 +24,13 @@ target_link_libraries(mlio-test
         GTest::GTest GTest::Main mlio
 )
 
+if(MLIO_BUILD_IMAGE_READER)
+    target_link_libraries(mlio-test
+        PRIVATE
+            opencv_core opencv_imgcodecs opencv_imgproc
+    )
+endif()
+
 # ------------------------------------------------------------
 # Tests
 # ------------------------------------------------------------


### PR DESCRIPTION
*Description of changes*:
Adds OpenCV as an optional using cmake. Set to `Off` by default.

*Testing*:
Tested by passing `-DMLIO_INCLUDE_OPENCV=ON` to cmake.