### PR TITLE
Implement python interface

### DIFF
--- a/src/mlio-py/mlio/__init__.py
+++ b/src/mlio-py/mlio/__init__.py
@@ -38,6 +38,9 @@ from mlio._core import\
     Example,\
     FieldTooLargeError,\
     File,\
+    ImageFrame,\
+    ImageReader,\
+    ImageReaderParams,\
     InMemoryStore,\
     InflateError,\
     InputStream,\
@@ -92,6 +95,9 @@ __all__ = [
     'Example',
     'FieldTooLargeError',
     'File',
+    'ImageFrame',
+    'ImageReader',
+    'ImageReaderParams',
     'InMemoryStore',
     'InflateError',
     'InputStream',

--- a/tests/mlio-py-test/test_csv_reader.py
+++ b/tests/mlio-py-test/test_csv_reader.py
@@ -31,7 +31,7 @@ def _test_dedupe_column_names(
     reader = mlio.CsvReader(reader_params, csv_params)
 
     example = reader.read_example()
-    names = [desc.name for desc in example.schema.descriptors]
+    names = [desc.name for desc in example.schema.attributes]
     assert names == expected_column_names
 
     record = [as_numpy(feature) for feature in example]

--- a/tests/mlio-py-test/test_data_reader_params.py
+++ b/tests/mlio-py-test/test_data_reader_params.py
@@ -61,7 +61,7 @@ def test_data_reader_params_members():
     assert rdr_prm.shuffle_instances is False
     assert rdr_prm.shuffle_window == 0
     assert rdr_prm.shuffle_seed is None
-    assert rdr_prm.reshuffle_each_epoch is False
+    assert rdr_prm.reshuffle_each_epoch is True
     assert rdr_prm.subsample_ratio is None
 
     rdr_prm.batch_size = 2

--- a/tests/mlio-py-test/test_image_reader.py
+++ b/tests/mlio-py-test/test_image_reader.py
@@ -1,0 +1,66 @@
+import os
+
+import mlio
+
+resources_dir = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), '../resources/images')
+
+
+def test_image_reader_jpeg():
+    filename = os.path.join(resources_dir, 'test_image_0.jpg')
+    dataset = [mlio.File(filename)]
+    rdr_prm = mlio.DataReaderParams(dataset=dataset,
+                                    batch_size=1)
+    img_prm = mlio.ImageReaderParams(img_frame=mlio.ImageFrame.NONE, resize=100, image_dimensions=[3,100,100], to_rgb=1)
+
+    reader = mlio.ImageReader(rdr_prm, img_prm)
+    example = reader.read_example()
+    tensor = example['value']
+
+    assert tensor.shape == (1, 100, 100, 3)
+    assert tensor.strides == (30000, 300, 3, 1)
+
+def test_image_reader_jpeg_no_resize():
+    filename = os.path.join(resources_dir, 'test_image_0.jpg')
+    dataset = [mlio.File(filename)]
+    rdr_prm = mlio.DataReaderParams(dataset=dataset,
+                                    batch_size=1)
+    img_prm = mlio.ImageReaderParams(img_frame=mlio.ImageFrame.NONE, image_dimensions=[3,50,50], to_rgb=1)
+
+    reader = mlio.ImageReader(rdr_prm, img_prm)
+    example = reader.read_example()
+    tensor = example['value']
+
+    assert tensor.shape == (1, 50, 50, 3)
+    assert tensor.strides == (7500, 150, 3, 1)
+
+
+def test_image_reader_png():
+    filename = os.path.join(resources_dir, 'test_image_0.png')
+    dataset = [mlio.File(filename)]
+    rdr_prm = mlio.DataReaderParams(dataset=dataset,
+                                    batch_size=1)
+    img_prm = mlio.ImageReaderParams(img_frame=mlio.ImageFrame.NONE, resize=100, image_dimensions=[3,100,100], to_rgb=1)
+
+    reader = mlio.ImageReader(rdr_prm, img_prm)
+    example = reader.read_example()
+    tensor = example['value']
+
+    assert tensor.shape == (1, 100, 100, 3)
+    assert tensor.strides == (30000, 300, 3, 1)
+
+
+def test_image_reader_recordio():
+    filename = os.path.join(resources_dir, 'test_image_0.rec')
+    dataset = [mlio.File(filename)]
+    rdr_prm = mlio.DataReaderParams(dataset=dataset,
+                                    batch_size=1)
+    img_prm = mlio.ImageReaderParams(img_frame=mlio.ImageFrame.RECORDIO, resize=100, image_dimensions=[3,100,100],
+                                     to_rgb=1)
+
+    reader = mlio.ImageReader(rdr_prm, img_prm)
+    example = reader.read_example()
+    tensor = example['value']
+
+    assert tensor.shape == (1, 100, 100, 3)
+    assert tensor.strides == (30000, 300, 3, 1)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Implemented python interface. This PR will be merged in after merging: https://github.com/rizwangilani/ml-io/pull/3

- fixed unit tests that were broken after mlio refactoring

*Testing:*
unit tests for python interface

```
python3 -m pytest -v
=========================================================================================== test session starts ============================================================================================
test_csv_reader.py::test_dedupe_column_names_no_duplicates PASSED                                                                                                                                    [  5%]
test_csv_reader.py::test_dedupe_column_names_duplicates PASSED                                                                                                                                       [ 11%]
test_csv_reader.py::test_dedupe_column_names_duplicates_recursive PASSED                                                                                                                             [ 17%]
test_csv_reader.py::test_dedupe_column_names_false PASSED                                                                                                                                            [ 23%]
test_csv_reader.py::test_dedupe_column_names_use_columns PASSED                                                                                                                                      [ 29%]
test_csv_reader.py::test_dedupe_column_names_duplicates_use_columns PASSED                                                                                                                           [ 35%]
test_csv_reader.py::test_dedupe_column_names_use_columns_by_index PASSED                                                                                                                             [ 41%]
test_csv_reader.py::test_dedupe_column_names_duplicates_use_columns_by_index PASSED                                                                                                                  [ 47%]
test_data_reader_params.py::test_recordio_protobuf_reader_params PASSED                                                                                                                              [ 52%]
test_data_reader_params.py::test_csv_params PASSED                                                                                                                                                   [ 58%]
test_data_reader_params.py::test_data_reader_params_members PASSED                                                                                                                                   [ 64%]
test_data_reader_params.py::test_csv_params_members PASSED                                                                                                                                           [ 70%]
test_data_readers.py::test_text_line_reader_params PASSED                                                                                                                                            [ 76%]
test_image_reader.py::test_image_reader_jpeg PASSED                                                                                                                                                  [ 82%]
test_image_reader.py::test_image_reader_jpeg_no_resize PASSED                                                                                                                                        [ 88%]
test_image_reader.py::test_image_reader_png PASSED                                                                                                                                                   [ 94%]
test_image_reader.py::test_image_reader_recordio PASSED                                                                                                                                              [100%]
```
Looks like one of the tests for data_reader_params is failing at the moment. Will be fixed in a separate commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
